### PR TITLE
Detection of location of Tessereact OCR OSD data

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,7 @@ the language at [the top of the file](https://github.com/daniperez/nautilus-ocr/
 ## Close on finish
 A dialog will be showed after OCR'ing the files, stating that the process 
 has finished. If you want to close the dialog automatically, just [uncomment the option `--auto-close`](https://github.com/daniperez/nautilus-ocr/blob/bdcf6579b98d48db05873b58d5d8e225cd453f3f/nautilus-ocr.sh#L108).
+
+# Contributors
+
+- @errotu: Debian support

--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ has finished. If you want to close the dialog automatically, just [uncomment the
 
 # Contributors
 
-- @errotu: Debian support
+- @errotu: Ubuntu support

--- a/nautilus-ocr.sh
+++ b/nautilus-ocr.sh
@@ -40,7 +40,7 @@ check_dependencies() {
 
     ZENITY_VERSION=$(type zenity &> /dev/null && zenity --version | tr -d '\n')
     TESSERACT_VERSION=$(type tesseract &> /dev/null && tesseract --version | head -1 |  cut -d' ' -f2 | tr -d '\n')
-    TESSERACT_OSD_DATA=/usr/share/tesseract/tessdata/osd.traineddata
+    TESSERACT_OSD_DATA=/usr/share/tesseract-ocr/4.00/tessdata/osd.traineddata
     OCRMYPDF_VERSION=$(type ocrmypdf &> /dev/null && ocrmypdf --version | tr -d '\n')
 
     if [[ "${ZENITY_VERSION}none" = "none" ]]; then
@@ -131,7 +131,7 @@ ocr_file() {
     LANGUAGE="$2"
     FILE_NO_EXTENSION=$(basename "${FILE%.*}")
 
-    ocrmypdf --redo-ocr -l "$LANGUAGE" "$FILE" "${FILE_NO_EXTENSION}_ocr.pdf" 2>&1
+    ocrmypdf -l "$LANGUAGE" "$FILE" "${FILE_NO_EXTENSION}_ocr.pdf" 2>&1
 }
 
 main

--- a/nautilus-ocr.sh
+++ b/nautilus-ocr.sh
@@ -170,7 +170,11 @@ ocr_file() {
     LANGUAGE="$2"
     FILE_NO_EXTENSION=$(basename "${FILE%.*}")
 
-    ocrmypdf -l "$LANGUAGE" "$FILE" "${FILE_NO_EXTENSION}_ocr.pdf" 2>&1
+    # Need to either --skip-text (re-use existing OCR
+    # text) or --redo-ocr (always ocr the pdf and add the
+    # resulting text). If not, ocrmypdf will fail with
+    # already ocr'ed pdfs.
+    ocrmypdf --skip-text -l "$LANGUAGE" "$FILE" "${FILE_NO_EXTENSION}_ocr.pdf" 2>&1
 }
 
 main


### PR DESCRIPTION
This is built up on #2 by @errotu .

- Detects the location of Tessereact OCR OSD data for major distributions
- Corrects the `ocrmypdf` command line to accept also ocr'ed pdfs.   